### PR TITLE
Expoesd parseParams method

### DIFF
--- a/config/common.config.ts
+++ b/config/common.config.ts
@@ -8,7 +8,7 @@ module.exports = {
   },
   output: {
     path: path.resolve(__dirname, '../dist'),
-    filename: 'ubirch-verification.js',
+    filename: 'index.js',
     libraryTarget: 'umd',
   },
   resolve: {

--- a/src/form-utils/form-utils.ts
+++ b/src/form-utils/form-utils.ts
@@ -104,7 +104,7 @@ export class UbirchFormUtils implements IUbirchFormUtils {
     }
   }
 
-  private parseParams = (paramsString: string, separator: string): DataParams => {
+  public parseParams = (paramsString: string, separator: string): DataParams => {
     const splitDataset = (dataset: string) => {
       const arraySeparator = ',';
 


### PR DESCRIPTION
I have updated the parseParams to be exposed as a public method - this is being used already by new verify-app when parsing legacy data.

Additionally I have changed back the main file to be index.js (convention) otherwise importing of types from the library is not working as intended.